### PR TITLE
visualization of quicksort now swaps values instead of changing them ind...

### DIFF
--- a/alvi/client/api/array.py
+++ b/alvi/client/api/array.py
@@ -8,3 +8,6 @@ def create_node(pipe, id, value):
         id=id,
         value=value,
     ))
+
+def swap_nodes(pipe, node1, node2):
+    pipe.send('swap_nodes', (1, ), dict(point1=node1, point2=node2))

--- a/alvi/client/containers/array.py
+++ b/alvi/client/containers/array.py
@@ -48,3 +48,11 @@ class Array(base.Container):
     def create_marker(self, name, node_id):
         node = self._nodes[node_id]
         return Marker(name, node)
+
+    def swap_nodes(self, index1, index2):
+        array.swap_nodes(
+            self._pipe,
+            node1={'id': self._nodes[index1].id},
+            node2={'id': self._nodes[index2].id}
+        )
+        self._nodes[index1], self._nodes[index2] = self._nodes[index2], self._nodes[index1]

--- a/alvi/client/scenes/quicksort.py
+++ b/alvi/client/scenes/quicksort.py
@@ -27,9 +27,9 @@ class Quicksort(Sort):
 
     def _quicksort(self, A, p, r):
         log.info('quicksort p=%d, r=%d' % (p, r))
-        self.qs_left.move(p)
-        self.qs_right.move(r)
         if p < r:
+            self.qs_left.move(p)
+            self.qs_right.move(r)
             q = self._partition(A, p, r)
             log.info('q = %d'%q)
             self._quicksort(A, p, q-1)
@@ -47,9 +47,9 @@ class Quicksort(Sort):
             if A[j] < x:
                 i += 1
                 self.part_i.move(i)
-                A[i], A[j] = A[j], A[i]
+                A.swap_nodes(i, j)
                 A.sync()
-        A[i+1], A[r] = A[r], A[i+1]
+        A.swap_nodes(i+1, r)
         self.part_partby.move(i+1)
         A.sync()
         return i+1

--- a/alvi/containers/array/cartesian.py
+++ b/alvi/containers/array/cartesian.py
@@ -16,6 +16,10 @@ class Cartesian(base.Array):
     def create_node(self, id, value):
         return dict(id=id, x=id+1, y=value)
 
+    @action('swap_points')
+    def swap_nodes(self, **kwargs):
+        return kwargs
+
     @action
     def create_marker(self, id, name, node_id):
         return dict(id=id, name=name, point_id=node_id)

--- a/alvi/templates/spaces/cartesian.html
+++ b/alvi/templates/spaces/cartesian.html
@@ -72,6 +72,15 @@
             points.push(point);
         }
 
+        function action_swap_points(action){
+            console.log('action_swap_points action=' + JSON.stringify(action));
+            var point1 = points[point_indexes[action.point1.id]];
+            var point2 = points[point_indexes[action.point2.id]];
+            var temp_x = point1.x;
+            point1.x = point2.x;
+            point2.x = temp_x;
+        }
+
         function action_create_line(line){
             console.log('create_line line=' + JSON.stringify(line));
             line_indexes[line.id] = lines.length;
@@ -98,6 +107,8 @@
         function action_move_marker(marker) {
             markers[marker_indexes[marker.id]].point_id = marker.point_id;
         }
+
+
 
         function update_scale() {
             var maxX = d3.max(points, function(d) { return d.x; });
@@ -260,6 +271,7 @@
         register_action('create_line', action_create_line);
         register_action('update_line', action_update_line);
         register_action('remove_line', action_remove_line);
+        register_action('swap_points', action_swap_points);
     </script>
 
 {% endblock %}


### PR DESCRIPTION
check out how quicksosrt swaps values in arrays - if you accept this, I'll get to work on:
- adding selenium tests for this (and combinations of swapping ans setting values in array)
- better visualization of markers for array (e.g: horizontal markers are not so great, when trying to show the range on which quicksort partition operates on)

I am also thinking on some configuring what granularity of sync a user want to see, eg: does he want to see all swaps, or just the state of the array, after each partition.
